### PR TITLE
Add Action to Draft Release

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,4 +1,4 @@
-name: Commit Check
+name: Commit
 
 on: [push]
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,31 @@
+name: Tag
+
+on:
+  push:
+    tags: 
+      - 'v*'
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[testing,development]
+      - name: Build
+        run: python setup.py sdist bdist_wheel
+      - name: Notes
+        run: |
+          VERSION=${GITHUB_REF/refs\/tags\//}
+          sed "1,/## \[$VERSION\]/d;/\[/Q" CHANGELOG.md > RELEASE-CHANGES.md
+      - name: Release (Draft)
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: RELEASE-CHANGES.md
+          files: dist/*
+          draft: true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![code-style-image]][black]
 [![documentation-image]][readthedocs]
-[![build-image]][travis]
 [![latest-version-image]][pypi]
 [![python-versions-image]][python]
 [![license-image]][mit]
@@ -167,8 +166,6 @@ Defense.
 [black]: https://github.com/psf/black
 [documentation-image]: https://img.shields.io/readthedocs/helix-datasets
 [readthedocs]: https://helix-datasets.readthedocs.io/
-[build-image]: https://img.shields.io/travis/com/helix-datasets/helix/main
-[travis]: https://app.travis-ci.com/github/helix-datasets/helix
 [latest-version-image]: https://img.shields.io/pypi/v/helix
 [pypi]: https://pypi.org/project/helix/
 [python-versions-image]: https://img.shields.io/pypi/pyversions/helix


### PR DESCRIPTION
- adds an Action to draft a release with the contents of the changelog on creation of a new tag
- renames Commit Action for consistency
- remove build badge (redundant now that we're using Actions)