### PR TITLE
Fix CLI Component Quote Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Correct documentation for `verbose_name` - property not optional.
+- Allow special characters (`=`, `:`) in quotes in CLI component parsing.
 
 ## [1.2.0] - 2022-01-18
 ### Added

--- a/helix/tests.py
+++ b/helix/tests.py
@@ -529,6 +529,21 @@ class UtilityTests(unittest.TestCase):
         )
         self.assertEqual(len(result["configuration"]), 3)
 
+    def test_specification_special_characters_outside_quotes(self):
+        specification = "name:one=special:character,two=special=character,three=special:character=something"
+
+        result = utils.parse(specification)
+
+        self.assertIn("one", result["configuration"].keys())
+        self.assertEqual(result["configuration"]["one"], "special:character")
+        self.assertIn("two", result["configuration"].keys())
+        self.assertEqual(result["configuration"]["two"], "special=character")
+        self.assertIn("three", result["configuration"].keys())
+        self.assertEqual(
+            result["configuration"]["three"], "special:character=something"
+        )
+        self.assertEqual(len(result["configuration"]), 3)
+
 
 class TestComponent(component.Component):
     name = "test"

--- a/helix/tests.py
+++ b/helix/tests.py
@@ -514,6 +514,21 @@ class UtilityTests(unittest.TestCase):
         self.assertEqual(result["name"], "name")
         self.assertEqual(result["configuration"], {})
 
+    def test_specification_parse_special_characters_in_quotes(self):
+        specification = "name:one='special:character',two=\"special=character\",three='special:character=something'"
+
+        result = utils.parse(specification)
+
+        self.assertIn("one", result["configuration"].keys())
+        self.assertEqual(result["configuration"]["one"], "special:character")
+        self.assertIn("two", result["configuration"].keys())
+        self.assertEqual(result["configuration"]["two"], "special=character")
+        self.assertIn("three", result["configuration"].keys())
+        self.assertEqual(
+            result["configuration"]["three"], "special:character=something"
+        )
+        self.assertEqual(len(result["configuration"]), 3)
+
 
 class TestComponent(component.Component):
     name = "test"

--- a/helix/utils.py
+++ b/helix/utils.py
@@ -837,7 +837,7 @@ def parse(specification):
 
     name = name.strip('"')
 
-    configuration = dict(re.findall(r'([^"\',]+)=(["\'].*?["\']|[^,]+)', configuration))
+    configuration = dict(re.findall(r'([^,=]+)=(["\'].*?["\']|[^,]+)', configuration))
     configuration = {k: v.strip("\"'") for k, v in configuration.items()}
 
     return {"name": name, "configuration": configuration}

--- a/helix/utils.py
+++ b/helix/utils.py
@@ -837,7 +837,7 @@ def parse(specification):
 
     name = name.strip('"')
 
-    configuration = dict(re.findall(r'([^,]+)=(["\'].*?["\']|[^,]+)', configuration))
+    configuration = dict(re.findall(r'([^"\',]+)=(["\'].*?["\']|[^,]+)', configuration))
     configuration = {k: v.strip("\"'") for k, v in configuration.items()}
 
     return {"name": name, "configuration": configuration}


### PR DESCRIPTION
- fixes a bug in CLI component specification that prevents special characters from being used inside quotes
- adds a unit test for the bug